### PR TITLE
refactor: helper CORS z konfiguracją .env

### DIFF
--- a/api/agent.js
+++ b/api/agent.js
@@ -1,10 +1,8 @@
+import { applyCors } from './cors.js';
+
 // /api/agent.js  — lekki „planner” z Places + syntetyczne menu (fallback).
 export default async function handler(req, res) {
-  // CORS
-  res.setHeader("Access-Control-Allow-Origin","*");
-  res.setHeader("Access-Control-Allow-Methods","GET,POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers","Content-Type, Authorization");
-  if (req.method === "OPTIONS") return res.status(200).end();
+  if (applyCors(req, res)) return;
 
   try {
     const body = req.method === "POST" ? (req.body || {}) : {};

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,13 +1,8 @@
 // /api/auth.js — endpoint logowania dla aplikacji FreeFlow
+import { applyCors } from './cors.js';
+
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "POST") {
     return res.status(405).json({ 

--- a/api/business-categories.js
+++ b/api/business-categories.js
@@ -1,5 +1,6 @@
 // /api/business-categories.js — endpoint do pobierania kategorii biznesu
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from './cors.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,14 +8,7 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "GET") {
     return res.status(405).json({ 

--- a/api/business-panel.js
+++ b/api/business-panel.js
@@ -1,5 +1,6 @@
 // /api/business-panel.js — endpoint dla paneli biznesowych
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from './cors.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,14 +8,7 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "GET") {
     return res.status(405).json({ 

--- a/api/business-register.js
+++ b/api/business-register.js
@@ -1,5 +1,6 @@
 // /api/business-register.js — endpoint rejestracji firm bez weryfikacji NIP
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from './cors.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,14 +8,7 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "POST") {
     return res.status(405).json({ 

--- a/api/cors.js
+++ b/api/cors.js
@@ -1,0 +1,57 @@
+export function applyCors(req, res) {
+  const rawOrigins = process.env.CORS_ALLOWED_ORIGINS ?? '*';
+  const allowedOrigins = rawOrigins
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+
+  const origin = req?.headers?.origin;
+  const allowAny = allowedOrigins.length === 0 || allowedOrigins.includes('*');
+  let allowOrigin;
+
+  if (allowAny) {
+    allowOrigin = origin || '*';
+  } else if (origin && allowedOrigins.includes(origin)) {
+    allowOrigin = origin;
+  }
+
+  if (allowOrigin) {
+    res.setHeader('Access-Control-Allow-Origin', allowOrigin);
+  }
+
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    if (typeof res.status === 'function') {
+      res.status(200);
+    } else {
+      res.statusCode = 200;
+    }
+    if (typeof res.end === 'function') {
+      res.end();
+    }
+    return true;
+  }
+
+  if (!allowOrigin && !allowAny) {
+    if (typeof res.status === 'function') {
+      res.status(403);
+    } else {
+      res.statusCode = 403;
+    }
+
+    const payload = { error: 'Origin not allowed' };
+    if (typeof res.json === 'function') {
+      res.json(payload);
+    } else {
+      res.setHeader('Content-Type', 'application/json');
+      if (typeof res.end === 'function') {
+        res.end(JSON.stringify(payload));
+      }
+    }
+    return true;
+  }
+
+  return false;
+}

--- a/api/env-test.js
+++ b/api/env-test.js
@@ -1,6 +1,8 @@
+import { applyCors } from './cors.js';
+
 // /api/env-test.js
-export default async function handler(_req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+export default async function handler(req, res) {
+  if (applyCors(req, res)) return;
   res.status(200).json({
     GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY ? 'OK' : 'MISSING',
     OPENAI_API_KEY: process.env.OPENAI_API_KEY ? 'OK' : 'MISSING',

--- a/api/gpt.js
+++ b/api/gpt.js
@@ -1,15 +1,10 @@
+import { applyCors } from './cors.js';
+
 // /api/gpt.js
 // Asystent FreeFlow – krótkie odpowiedzi PL
 
 export default async function handler(req, res) {
-  if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    return res.status(204).end();
-  }
-
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  if (applyCors(req, res)) return;
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });

--- a/api/health.js
+++ b/api/health.js
@@ -1,6 +1,8 @@
+import { applyCors } from './cors.js';
+
 // /api/health.js
-export default async function handler(_req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+export default async function handler(req, res) {
+  if (applyCors(req, res)) return;
   return res.status(200).json({
     status: 'ok',
     service: 'freeflow-backend',

--- a/api/order-routing.js
+++ b/api/order-routing.js
@@ -1,5 +1,6 @@
 // /api/order-routing.js — endpoint do kierowania zamówień do restauracji
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from './cors.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,14 +8,7 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "POST") {
     return res.status(405).json({ 

--- a/api/places.js
+++ b/api/places.js
@@ -1,17 +1,8 @@
-// --- CORS (wspólne)
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-};
+import { applyCors } from './cors.js';
 
 // szybka obsługa OPTIONS
 export default async function handler(req, res) {
-  if (req.method === 'OPTIONS') {
-    Object.entries(CORS_HEADERS).forEach(([k, v]) => res.setHeader(k, v));
-    return res.status(204).end();
-  }
-  Object.entries(CORS_HEADERS).forEach(([k, v]) => res.setHeader(k, v));
+  if (applyCors(req, res)) return;
 
   try {
     if (!process.env.GOOGLE_MAPS_API_KEY) {

--- a/api/tts.js
+++ b/api/tts.js
@@ -1,14 +1,9 @@
 // /api/tts.js
 // Serverless TTS (OpenAI tts-1) → MP3
+import { applyCors } from './cors.js';
+
 export default async function handler(req, res) {
-  // CORS
-  if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    return res.status(204).end();
-  }
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  if (applyCors(req, res)) return;
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });

--- a/api/whisper.js
+++ b/api/whisper.js
@@ -1,16 +1,12 @@
 // api/whisper.js
 // Vercel / Node runtime. Przyjmuje audio/webm z przeglądarki i przepuszcza do OpenAI Whisper.
 // Env: OPENAI_API_KEY (ustaw w Vercel → Settings → Environment Variables)
+import { applyCors } from './cors.js';
 
 export const config = { api: { bodyParser: false } };
 
 export default async function handler(req, res) {
-  if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    return res.status(204).end();
-  }
+  if (applyCors(req, res)) return;
   if (req.method !== 'POST') return res.status(405).end('Method Not Allowed');
 
   try {
@@ -32,11 +28,9 @@ export default async function handler(req, res) {
 
     const data = await r.json().catch(() => ({}));
 
-    res.setHeader('Access-Control-Allow-Origin', '*');
     if (!r.ok) return res.status(r.status).json(data);
     return res.json({ text: data.text || '' });
   } catch (e) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
     return res.status(500).json({ error: String(e?.message || e) });
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "vercel dev --listen 3001",
     "build": "echo 'nothing to build'",
-    "test": "node -e \"console.log('OK')\""
+    "test": "node test/cors.test.js && node -e \"console.log('OK')\""
   },
   "dependencies": {
     "openai": "^4.56.0",

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { applyCors } from '../api/cors.js';
+
+function createReq({ method = 'GET', origin } = {}) {
+  const headers = {};
+  if (origin !== undefined) headers.origin = origin;
+  return { method, headers };
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    ended: false,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    end(payload) {
+      if (payload !== undefined) {
+        this.body = payload;
+      }
+      this.ended = true;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.ended = true;
+      return this;
+    },
+  };
+}
+
+async function run(name, fn) {
+  try {
+    await fn();
+    console.log(`\u2713 ${name}`);
+  } catch (error) {
+    console.error(`\u2717 ${name}`);
+    throw error;
+  }
+}
+
+const originalOrigins = process.env.CORS_ALLOWED_ORIGINS;
+
+try {
+  await run('wildcard allows any origin header', () => {
+    process.env.CORS_ALLOWED_ORIGINS = '*';
+    const req = createReq({ method: 'GET', origin: 'http://example.com' });
+    const res = createRes();
+
+    const handled = applyCors(req, res);
+
+    assert.equal(handled, false);
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'http://example.com');
+    assert.equal(res.headers['Access-Control-Allow-Methods'], 'GET,POST,OPTIONS');
+    assert.equal(res.headers['Access-Control-Allow-Headers'], 'Content-Type, Authorization');
+    assert.equal(res.ended, false);
+  });
+
+  await run('wildcard falls back to * when origin missing', () => {
+    process.env.CORS_ALLOWED_ORIGINS = '*';
+    const req = createReq({ method: 'GET' });
+    const res = createRes();
+
+    const handled = applyCors(req, res);
+
+    assert.equal(handled, false);
+    assert.equal(res.headers['Access-Control-Allow-Origin'], '*');
+  });
+
+  await run('options request handled immediately', () => {
+    process.env.CORS_ALLOWED_ORIGINS = '*';
+    const req = createReq({ method: 'OPTIONS', origin: 'http://example.com' });
+    const res = createRes();
+
+    const handled = applyCors(req, res);
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.ended, true);
+  });
+
+  await run('whitelist allows configured origins', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173,https://freeflow-front.vercel.app';
+    const req = createReq({ method: 'GET', origin: 'https://freeflow-front.vercel.app' });
+    const res = createRes();
+
+    const handled = applyCors(req, res);
+
+    assert.equal(handled, false);
+    assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://freeflow-front.vercel.app');
+    assert.equal(res.headers['Access-Control-Allow-Methods'], 'GET,POST,OPTIONS');
+    assert.equal(res.headers['Access-Control-Allow-Headers'], 'Content-Type, Authorization');
+  });
+
+  await run('whitelist blocks other origins', () => {
+    process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173,https://freeflow-front.vercel.app';
+    const req = createReq({ method: 'GET', origin: 'https://not-allowed.example' });
+    const res = createRes();
+
+    const handled = applyCors(req, res);
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(res.body, { error: 'Origin not allowed' });
+    assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
+  });
+
+  console.log('All CORS tests passed');
+} finally {
+  if (originalOrigins === undefined) {
+    delete process.env.CORS_ALLOWED_ORIGINS;
+  } else {
+    process.env.CORS_ALLOWED_ORIGINS = originalOrigins;
+  }
+}


### PR DESCRIPTION
## Podsumowanie
- dodano wspólną funkcję `applyCors` czytającą `CORS_ALLOWED_ORIGINS` z env i obsługującą preflight/403
- wszystkie endpointy w katalogu `api/` korzystają teraz z helpera zamiast ręcznych nagłówków
- przygotowano test integracyjny `test/cors.test.js` oraz zaktualizowano `npm test`, aby obejmował scenariusze CORS

## Dlaczego
- centralny helper zmniejsza duplikację nagłówków CORS i umożliwia kontrolę dozwolonych domen z poziomu `.env`
- testy regresyjne gwarantują poprawną obsługę zarówno trybu wildcard, jak i białej listy

## Checklista
- [ ] `npm ci` *(błąd: brak pliku package-lock.json uniemożliwia wykonanie polecenia w tym repozytorium)*
- [x] `npm run lint --if-present`
- [x] `npm run build --if-present`
- [x] `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68ced46227bc832ebb50070f3bd2262c