### PR TITLE
fix: helper CORS z env allowlist

### DIFF
--- a/api/agent.js
+++ b/api/agent.js
@@ -1,10 +1,8 @@
+import { applyCors } from '../lib/cors.js';
+
 // /api/agent.js  — lekki „planner” z Places + syntetyczne menu (fallback).
 export default async function handler(req, res) {
-  // CORS
-  res.setHeader("Access-Control-Allow-Origin","*");
-  res.setHeader("Access-Control-Allow-Methods","GET,POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers","Content-Type, Authorization");
-  if (req.method === "OPTIONS") return res.status(200).end();
+  if (applyCors(req, res)) return;
 
   try {
     const body = req.method === "POST" ? (req.body || {}) : {};

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,13 +1,8 @@
 // /api/auth.js — endpoint logowania dla aplikacji FreeFlow
+import { applyCors } from '../lib/cors.js';
+
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "POST") {
     return res.status(405).json({ 

--- a/api/business-categories.js
+++ b/api/business-categories.js
@@ -1,5 +1,6 @@
 // /api/business-categories.js — endpoint do pobierania kategorii biznesu
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from '../lib/cors.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,14 +8,7 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "GET") {
     return res.status(405).json({ 

--- a/api/business-panel.js
+++ b/api/business-panel.js
@@ -1,5 +1,6 @@
 // /api/business-panel.js — endpoint dla paneli biznesowych
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from '../lib/cors.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,14 +8,7 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "GET") {
     return res.status(405).json({ 

--- a/api/business-register.js
+++ b/api/business-register.js
@@ -1,5 +1,6 @@
 // /api/business-register.js — endpoint rejestracji firm bez weryfikacji NIP
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from '../lib/cors.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,14 +8,7 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "POST") {
     return res.status(405).json({ 

--- a/api/env-test.js
+++ b/api/env-test.js
@@ -1,6 +1,8 @@
+import { applyCors } from '../lib/cors.js';
+
 // /api/env-test.js
-export default async function handler(_req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+export default async function handler(req, res) {
+  if (applyCors(req, res)) return;
   res.status(200).json({
     GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY ? 'OK' : 'MISSING',
     OPENAI_API_KEY: process.env.OPENAI_API_KEY ? 'OK' : 'MISSING',

--- a/api/gpt.js
+++ b/api/gpt.js
@@ -1,15 +1,10 @@
+import { applyCors } from '../lib/cors.js';
+
 // /api/gpt.js
 // Asystent FreeFlow – krótkie odpowiedzi PL
 
 export default async function handler(req, res) {
-  if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    return res.status(204).end();
-  }
-
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  if (applyCors(req, res)) return;
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });

--- a/api/health.js
+++ b/api/health.js
@@ -1,6 +1,8 @@
+import { applyCors } from '../lib/cors.js';
+
 // /api/health.js
-export default async function handler(_req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+export default async function handler(req, res) {
+  if (applyCors(req, res)) return;
   return res.status(200).json({
     status: 'ok',
     service: 'freeflow-backend',

--- a/api/order-routing.js
+++ b/api/order-routing.js
@@ -1,5 +1,6 @@
 // /api/order-routing.js — endpoint do kierowania zamówień do restauracji
 import { createClient } from '@supabase/supabase-js';
+import { applyCors } from '../lib/cors.js';
 
 const supabase = createClient(
   process.env.SUPABASE_URL,
@@ -7,14 +8,7 @@ const supabase = createClient(
 );
 
 export default async function handler(req, res) {
-  // CORS headers
-  res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  
-  if (req.method === "OPTIONS") {
-    return res.status(200).end();
-  }
+  if (applyCors(req, res)) return;
 
   if (req.method !== "POST") {
     return res.status(405).json({ 

--- a/api/places.js
+++ b/api/places.js
@@ -1,17 +1,8 @@
-// --- CORS (wspólne)
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-};
+import { applyCors } from '../lib/cors.js';
 
 // szybka obsługa OPTIONS
 export default async function handler(req, res) {
-  if (req.method === 'OPTIONS') {
-    Object.entries(CORS_HEADERS).forEach(([k, v]) => res.setHeader(k, v));
-    return res.status(204).end();
-  }
-  Object.entries(CORS_HEADERS).forEach(([k, v]) => res.setHeader(k, v));
+  if (applyCors(req, res)) return;
 
   try {
     if (!process.env.GOOGLE_MAPS_API_KEY) {

--- a/api/tts.js
+++ b/api/tts.js
@@ -1,14 +1,9 @@
 // /api/tts.js
 // Serverless TTS (OpenAI tts-1) → MP3
+import { applyCors } from '../lib/cors.js';
+
 export default async function handler(req, res) {
-  // CORS
-  if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST,OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    return res.status(204).end();
-  }
-  res.setHeader('Access-Control-Allow-Origin', '*');
+  if (applyCors(req, res)) return;
 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });

--- a/api/whisper.js
+++ b/api/whisper.js
@@ -1,16 +1,12 @@
 // api/whisper.js
 // Vercel / Node runtime. Przyjmuje audio/webm z przeglądarki i przepuszcza do OpenAI Whisper.
 // Env: OPENAI_API_KEY (ustaw w Vercel → Settings → Environment Variables)
+import { applyCors } from '../lib/cors.js';
 
 export const config = { api: { bodyParser: false } };
 
 export default async function handler(req, res) {
-  if (req.method === 'OPTIONS') {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-    return res.status(204).end();
-  }
+  if (applyCors(req, res)) return;
   if (req.method !== 'POST') return res.status(405).end('Method Not Allowed');
 
   try {
@@ -32,11 +28,9 @@ export default async function handler(req, res) {
 
     const data = await r.json().catch(() => ({}));
 
-    res.setHeader('Access-Control-Allow-Origin', '*');
     if (!r.ok) return res.status(r.status).json(data);
     return res.json({ text: data.text || '' });
   } catch (e) {
-    res.setHeader('Access-Control-Allow-Origin', '*');
     return res.status(500).json({ error: String(e?.message || e) });
   }
 }

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -1,0 +1,38 @@
+const parseList = (v = '') =>
+  v
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+
+export function applyCors(req, res) {
+  const conf = process.env.CORS_ALLOWED_ORIGINS || '';
+  const allowAll = conf === '*';
+  const allowList = parseList(conf);
+  const origin = req.headers?.origin || '';
+
+  res.setHeader('Vary', 'Origin');
+  if (!origin) {
+    if (req.method === 'OPTIONS') {
+      res.status(204).end();
+      return true;
+    }
+    return false;
+  }
+
+  const isAllowed = allowAll || allowList.includes(origin);
+  if (!isAllowed) {
+    res.status(403).json({ error: 'Origin not allowed' });
+    return true;
+  }
+
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return true;
+  }
+
+  return false;
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "dev": "vercel dev --listen 3001",
     "build": "echo 'nothing to build'",
-    "test": "node -e \"console.log('OK')\""
+    "test": "node --test test/cors.spec.mjs && node -e \"console.log('OK')\""
   },
   "dependencies": {
     "openai": "^4.56.0",

--- a/test/cors.spec.mjs
+++ b/test/cors.spec.mjs
@@ -1,0 +1,103 @@
+import test, { after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import healthHandler from '../api/health.js';
+import placesHandler from '../api/places.js';
+
+const originalCors = process.env.CORS_ALLOWED_ORIGINS;
+
+after(() => {
+  if (originalCors === undefined) {
+    delete process.env.CORS_ALLOWED_ORIGINS;
+  } else {
+    process.env.CORS_ALLOWED_ORIGINS = originalCors;
+  }
+});
+
+function createReq({ method = 'GET', origin, query = {}, body } = {}) {
+  const headers = {};
+  if (origin !== undefined) {
+    headers.origin = origin;
+  }
+  return { method, headers, query, body };
+}
+
+function createRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    ended: false,
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      this.ended = true;
+      return this;
+    },
+    end(payload) {
+      if (payload !== undefined) {
+        this.body = payload;
+      }
+      this.ended = true;
+      return this;
+    },
+  };
+}
+
+test('OPTIONS /api/places allows configured origin and returns 204', async () => {
+  process.env.CORS_ALLOWED_ORIGINS = 'https://freeflow-frontend-seven.vercel.app,http://localhost:5173';
+
+  const req = createReq({
+    method: 'OPTIONS',
+    origin: 'https://freeflow-frontend-seven.vercel.app',
+  });
+  const res = createRes();
+
+  await placesHandler(req, res);
+
+  assert.equal(res.statusCode, 204);
+  assert.equal(res.ended, true);
+  assert.equal(res.headers['Access-Control-Allow-Origin'], 'https://freeflow-frontend-seven.vercel.app');
+  assert.equal(res.headers['Access-Control-Allow-Methods'], 'GET,POST,OPTIONS');
+  assert.equal(res.headers['Access-Control-Allow-Headers'], 'Content-Type, Authorization');
+  assert.equal(res.headers['Vary'], 'Origin');
+});
+
+test('GET /api/health without Origin passes through', async () => {
+  process.env.CORS_ALLOWED_ORIGINS = 'https://freeflow-frontend-seven.vercel.app,http://localhost:5173';
+
+  const req = createReq({ method: 'GET' });
+  const res = createRes();
+
+  await healthHandler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.ended, true);
+  assert.equal(res.headers['Vary'], 'Origin');
+  assert.equal(res.body?.status, 'ok');
+});
+
+test('GET /api/places with disallowed origin is blocked', async () => {
+  process.env.CORS_ALLOWED_ORIGINS = 'https://freeflow-frontend-seven.vercel.app,http://localhost:5173';
+
+  const req = createReq({
+    method: 'GET',
+    origin: 'https://not-allowed.example',
+    query: {},
+  });
+  const res = createRes();
+
+  await placesHandler(req, res);
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(res.ended, true);
+  assert.deepEqual(res.body, { error: 'Origin not allowed' });
+  assert.equal(res.headers['Access-Control-Allow-Origin'], undefined);
+  assert.equal(res.headers['Vary'], 'Origin');
+});


### PR DESCRIPTION
## Co
- przeniesiono `applyCors` do `lib/cors.js`, ustawiając nagłówki `Vary`, `Access-Control-Allow-*`, obsługując `OPTIONS` 204 oraz zwracając 403 dla originów spoza allowlisty
- wszystkie endpointy w `/api` korzystają z helpera z `lib/cors.js`
- dodano test integracyjny `test/cors.spec.mjs` oraz aktualizację skryptu `npm test`

## Dlaczego
- scentralizowany helper wymusza jednolitą konfigurację CORS i chroni backend przed nieautoryzowanym dostępem

## Checklista
- [ ] `npm ci` *(błąd: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1`)*
- [x] `npm run lint --if-present`
- [x] `npm run build --if-present`
- [x] `npm test --if-present`

## Dodatkowe kroki
- Ustawić w Vercel (Production/Preview) zmienną `CORS_ALLOWED_ORIGINS=https://freeflow-frontend-seven.vercel.app,http://localhost:5173` i wykonać redeploy backendu.


------
https://chatgpt.com/codex/tasks/task_e_68ced46227bc832ebb50070f3bd2262c